### PR TITLE
Improve event search

### DIFF
--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -86,7 +86,7 @@ export async function getEventsFromName(
         AND: name.split(/\s+/).map((word) => ({
           name: {
             contains: word,
-            mode: "insensitive",
+            mode: "insensitive" as "default" | "insensitive",
           },
         })),
       };

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -78,20 +78,19 @@ export async function getEventsFromName(
   limit: number,
   exact: boolean,
 ) {
-  const filter = exact
-    ? {
-        name: name,
-      }
-    : {
-        AND: name.split(/\s+/).map((word) => ({
-          name: {
-            contains: word,
-            mode: "insensitive",
-          },
-        })),
-      };
   return await prisma.event.findMany({
-    where: filter,
+    where: exact
+      ? {
+          name: name,
+        }
+      : {
+          AND: name.split(/\s+/).map((word) => ({
+            name: {
+              contains: word,
+              mode: "insensitive",
+            },
+          })),
+        },
     select: {
       id: true,
       name: true,

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -83,9 +83,12 @@ export async function getEventsFromName(
         name: name,
       }
     : {
-        name: {
-          contains: name,
-        },
+        AND: name.split(/\s+/).map((word) => ({
+          name: {
+            contains: word,
+            mode: "insensitive",
+          },
+        })),
       };
   return await prisma.event.findMany({
     where: filter,

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -78,19 +78,20 @@ export async function getEventsFromName(
   limit: number,
   exact: boolean,
 ) {
+  const filter = exact
+    ? {
+        name: name,
+      }
+    : {
+        AND: name.split(/\s+/).map((word) => ({
+          name: {
+            contains: word,
+            mode: "insensitive",
+          },
+        })),
+      };
   return await prisma.event.findMany({
-    where: exact
-      ? {
-          name: name,
-        }
-      : {
-          AND: name.split(/\s+/).map((word) => ({
-            name: {
-              contains: word,
-              mode: "insensitive",
-            },
-          })),
-        },
+    where: filter,
     select: {
       id: true,
       name: true,


### PR DESCRIPTION
This splits the search query on whitespace and matches each word case-insensitively

Before:

![image](https://github.com/NhatMinh0208/timetable-together/assets/65121402/c71158c5-6d5f-4f61-9624-466be786d172)

![image](https://github.com/NhatMinh0208/timetable-together/assets/65121402/31f38b5b-535a-41fb-9a67-9857a339380c)

![image](https://github.com/NhatMinh0208/timetable-together/assets/65121402/bf9feabe-8e52-4e1e-8eae-802950e9a6bc)

After:

![image](https://github.com/NhatMinh0208/timetable-together/assets/65121402/d25656cf-d127-4d7f-b463-5e63c3ca21b1)
