### PR TITLE
Make headers sticky

### DIFF
--- a/app/components/timetable-day.tsx
+++ b/app/components/timetable-day.tsx
@@ -5,9 +5,11 @@ import { TimetableBlock } from "@/app/lib/types";
 import { TICKS_IN_DAY, weekdays } from "@/app/lib/constants";
 
 export function TimetableDay({
+  startRow,
   dayBlocks,
   handleAttendanceUpdate,
 }: {
+  startRow: number;
   dayBlocks: TimetableBlock[][];
   handleAttendanceUpdate: (eventId: string, scheduleId: string) => void;
 }) {
@@ -23,7 +25,7 @@ export function TimetableDay({
           gridColumnEnd: j * 4 + 5,
         }}
         className={clsx(
-          "border-t-2 border-l-2 border-l-slate-300 border-t-slate-600",
+          "border-t-2 border-l-2 border-l-slate-300 border-t-slate-300",
         )}
       ></div>,
     );
@@ -79,6 +81,10 @@ focus-visible:outline-offset-2 focus-visible:outline-indigo-600",
   return (
     <div
       style={{
+        gridRowStart: startRow + 2,
+        gridColumnStart: 2,
+        gridRowEnd: startRow + dayBlocks.length + 2,
+        gridColumnEnd: 98,
         gridTemplateColumns: "repeat(96,60px)",
         gridTemplateRows: "repeat(" + dayBlocks.length.toString() + ",80px)",
       }}

--- a/app/components/timetable-window.tsx
+++ b/app/components/timetable-window.tsx
@@ -28,82 +28,104 @@ export function TimetableWindow({
     }
   }
   for (const day of blocksByDay) while (day.length < 2) day.push([]);
+
+  let cnt1 = 0;
+  let cnt2 = 0;
+
   return (
-    <div className="flex flex-row text-xs overflow-auto">
-      <div className="flex flex-col w-16 shrink-0">
-        <div className={clsx("h-6 shrink-0")}></div>
-        {blocksByDay.map((day, i) => {
+    <div
+      style={{
+        gridTemplateColumns: "repeat(97,60px)",
+        gridTemplateRows:
+          "24px repeat(" +
+          blocksByDay
+            .map((x) => x.length)
+            .reduce((sum, cur) => {
+              return sum + cur;
+            }, 0) +
+          ",80px)",
+      }}
+      className="grid text-xs overflow-auto"
+    >
+      <div className={clsx("h-6 shrink-0")}></div>
+      {blocksByDay.map((day, i) => {
+        cnt1 += day.length;
+        return (
+          <div
+            key={i}
+            style={{
+              gridRowStart: cnt1 - day.length + 2,
+              gridColumnStart: 1,
+              gridRowEnd: cnt1 + 2,
+              gridColumnEnd: 2,
+            }}
+            className={clsx(
+              "bg-slate-200 border-t-slate-600 border-t-2 border-r-slate-600 border-r-2 place-content-center text-center shrink-0 sticky left-0",
+            )}
+          >
+            <div className="text-sm">{weekdays[i]}</div>
+            <div className="text-xl">
+              {new Date(window.getTime() + TICKS_IN_DAY * i).getDate()}
+            </div>
+          </div>
+        );
+      })}
+      {(() => {
+        const HOURS = [
+          "12AM",
+          "1AM",
+          "2AM",
+          "3AM",
+          "4AM",
+          "5AM",
+          "6AM",
+          "7AM",
+          "8AM",
+          "9AM",
+          "10AM",
+          "11AM",
+          "12PM",
+          "1PM",
+          "2PM",
+          "3PM",
+          "4PM",
+          "5PM",
+          "6PM",
+          "7PM",
+          "8PM",
+          "9PM",
+          "10PM",
+          "11PM",
+        ];
+        return HOURS.map((x, i) => {
           return (
             <div
-              key={i}
               style={{
-                height: day.length * 80,
+                gridRowStart: 1,
+                gridColumnStart: i * 4 + 2,
+                gridRowEnd: 2,
+                gridColumnEnd: i * 4 + 3,
               }}
-              className={clsx(
-                "border-slate-600 border-t-2 flex flex-col place-content-center text-center shrink-0",
-              )}
+              key={x}
+              className="bg-slate-200 w-60 border-l-2 border-l-slate-600 border-b-2 border-b-slate-600 align-bottom shrink-0 sticky top-0"
             >
-              <div className="text-sm">{weekdays[i]}</div>
-              <div className="text-xl">
-                {new Date(window.getTime() + TICKS_IN_DAY * i).getDate()}
-              </div>
+              {x}
             </div>
           );
-        })}
-      </div>
-      <div className="flex flex-col">
-        <div className={clsx("flex flex-row h-6 shrink-0")}>
-          {(() => {
-            const HOURS = [
-              "12AM",
-              "1AM",
-              "2AM",
-              "3AM",
-              "4AM",
-              "5AM",
-              "6AM",
-              "7AM",
-              "8AM",
-              "9AM",
-              "10AM",
-              "11AM",
-              "12PM",
-              "1PM",
-              "2PM",
-              "3PM",
-              "4PM",
-              "5PM",
-              "6PM",
-              "7PM",
-              "8PM",
-              "9PM",
-              "10PM",
-              "11PM",
-            ];
-            return HOURS.map((x) => {
-              return (
-                <div
-                  key={x}
-                  className="w-60 border-l-2 border-slate-300 align-bottom shrink-0"
-                >
-                  {x}
-                </div>
-              );
-            });
-          })()}
-        </div>
+        });
+      })()}
 
-        {blocksByDay.map((day, i) => {
-          return (
-            <div key={i}>
-              <TimetableDay
-                dayBlocks={day}
-                handleAttendanceUpdate={handleAttendanceUpdate}
-              />
-            </div>
-          );
-        })}
-      </div>
+      {blocksByDay.map((day, i) => {
+        cnt2 += day.length;
+        return (
+          <TimetableDay
+            startRow={cnt2 - day.length}
+            dayBlocks={day}
+            handleAttendanceUpdate={handleAttendanceUpdate}
+            key={i}
+          />
+        );
+      })}
       {/* {blocks.map((block) => {
     return (
         <button className={clsx(


### PR DESCRIPTION
This PR changes the calendar layout to a grid so that every component is in a grid span. It then makes the calendar headers sticky so it doesn't drift off screen when the user scrolls.

Resolves #25.