### PR TITLE
Fix navbar height part 2

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,7 +30,7 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body className={clsx(inter.className, "h-dvh w-dvw")}>
-        <div className="w-dvw h-[8dvh] px-2 pt-2 pb-0 grow-0">
+        <div className="w-dvw px-2 pt-2 pb-0 grow-0">
           <div
             className={
               "h-full px-2 py-2 space-y-2 rounded-lg bg-slate-200 flex flex-row align-middle"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export default async function RootLayout({
   const session = await auth();
   return (
     <html lang="en">
-      <body className={clsx(inter.className, "h-dvh w-dvw")}>
+      <body className={clsx(inter.className, "h-dvh w-dvw flex flex-col")}>
         <div className="w-dvw px-2 pt-2 pb-0 grow-0">
           <div
             className={
@@ -62,7 +62,7 @@ export default async function RootLayout({
             )}
           </div>
         </div>
-        <div className="w-dvw h-[92dvh]  grow-0">{children}</div>
+        <div className="w-dvw min-h-0 grow">{children}</div>
       </body>
     </html>
   );


### PR DESCRIPTION
Before: Forcing 92dvh can cause the content to not fill the screen or go off-screen.

![image](https://github.com/NhatMinh0208/timetable-together/assets/65121402/1ea08cd4-0c35-4867-98bd-948338a647ca)
![image](https://github.com/NhatMinh0208/timetable-together/assets/65121402/3c2e0751-63b8-4d2d-bcae-143d8964340e)

After: The content fits the screen as intended.

![image](https://github.com/NhatMinh0208/timetable-together/assets/65121402/85cecb6a-75f2-44cc-a138-a36d6f57a6e6)
![image](https://github.com/NhatMinh0208/timetable-together/assets/65121402/4cc0291e-d2bd-48d9-ab1b-e76c0793b541)