### PR TITLE
Fix navbar height part 3

### DIFF
--- a/app/components/link-buttons.tsx
+++ b/app/components/link-buttons.tsx
@@ -46,7 +46,7 @@ export function Timetable({ labl }: { labl: string }) {
   return (
     <Link
       href={"/timetable"}
-      className="flex mx-auto justify-center rounded-md bg-orange-400 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-orange-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+      className="flex justify-center rounded-md bg-orange-400 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-orange-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
     >
       {labl}
     </Link>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,7 +30,7 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body className={clsx(inter.className, "h-dvh w-dvw")}>
-        <div className="w-dvw h-[8dvh] px-2 pt-2 pb-0 grow-0">
+        <div className="w-dvw px-2 pt-2 pb-0 grow-0">
           <div
             className={
               "h-full px-2 py-2 space-y-2 rounded-lg bg-slate-200 flex flex-row align-middle"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,37 +30,31 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body className={clsx(inter.className, "flex h-dvh flex-col")}>
-        <div className="w-dvw px-2 pt-2 pb-0 grow-0">
-          <div
-            className={
-              "h-full px-2 py-2 space-y-2 rounded-lg bg-slate-200 flex flex-row align-middle"
-            }
-          >
-            <Link
+        <div className="flex rounded-lg bg-slate-200">
+          <Link
               href="/"
               className="h-full space-y-2 rounded-lg bg-slate-200 flex flex-row align-middle"
             >
-              <Image src={Icon} alt="Logo" width={50} height={50}></Image>
+            <Image src={Icon} alt="Logo" width={50} height={50}></Image>
+            <span className="w-2"></span>
+            <span className="text-2xl">Timetable Together</span>
+          </Link>
+          <span className="grow"></span>
+          {session ? (
+            <>
+              <span className="text-2xl">{session?.user?.name}</span>
               <span className="w-2"></span>
-              <span className="text-2xl">Timetable Together</span>
-            </Link>
-            <span className="grow"></span>
-            {session ? (
-              <>
-                <span className="text-2xl">{session?.user?.name}</span>
-                <span className="w-2"></span>
-                <Timetable labl="Timetable" />
-                <span className="w-2"></span>
-                <Logout labl="Sign out" />
-              </>
-            ) : (
-              <>
-                <Login labl={"Sign in"} />
-                <span className="w-2"></span>
-                <Register labl={"Register"} />
-              </>
-            )}
-          </div>
+              <Timetable labl="Timetable" />
+              <span className="w-2"></span>
+              <Logout labl="Sign out" />
+            </>
+          ) : (
+            <>
+              <Login labl={"Sign in"} />
+              <span className="w-2"></span>
+              <Register labl={"Register"} />
+            </>
+          )}
         </div>
         <div className="w-dvw min-h-0 grow">{children}</div>
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,10 +31,7 @@ export default async function RootLayout({
     <html lang="en">
       <body className={clsx(inter.className, "flex h-dvh flex-col")}>
         <header className="mx-2 mt-2 flex items-center rounded-lg bg-slate-200 p-2">
-          <Link
-            href="/"
-              className="h-full space-y-2 rounded-lg bg-slate-200 flex flex-row align-middle"
-          >
+          <Link href="/" className="flex items-center">
             <Image src={Icon} alt="Logo" width={50} height={50}></Image>
             <span className="w-2"></span>
             <span className="text-2xl">Timetable Together</span>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,11 +31,10 @@ export default async function RootLayout({
     <html lang="en">
       <body className={clsx(inter.className, "flex h-dvh flex-col")}>
         <header className="mx-2 mt-2 flex items-center gap-2 rounded-lg bg-slate-200 p-2">
-          <Link href="/" className="flex items-center gap-2">
+          <Link href="/" className="mr-auto flex items-center gap-2">
             <Image src={Icon} alt="Logo" width={50} height={50}></Image>
             <span className="text-2xl">Timetable Together</span>
           </Link>
-          <span className="grow"></span>
           {session ? (
             <>
               <span className="text-2xl">{session?.user?.name}</span>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export default async function RootLayout({
   const session = await auth();
   return (
     <html lang="en">
-      <body className={clsx(inter.className, "h-dvh w-dvw")}>
+      <body className={clsx(inter.className, "h-dvh w-dvw flex flex-col")}>
         <div className="w-dvw px-2 pt-2 pb-0 grow-0">
           <div
             className={
@@ -62,7 +62,7 @@ export default async function RootLayout({
             )}
           </div>
         </div>
-        <div className="w-dvw h-[92dvh]  grow-0">{children}</div>
+        <div className="w-dvw min-h-0 grow">{children}</div>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -48,7 +48,7 @@ export default async function RootLayout({
             </>
           )}
         </header>
-        <div className="w-dvw min-h-0 grow">{children}</div>
+        <main className="min-h-0 grow">{children}</main>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,25 +30,21 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body className={clsx(inter.className, "flex h-dvh flex-col")}>
-        <header className="mx-2 mt-2 flex items-center rounded-lg bg-slate-200 p-2">
-          <Link href="/" className="flex items-center">
+        <header className="mx-2 mt-2 flex items-center gap-2 rounded-lg bg-slate-200 p-2">
+          <Link href="/" className="flex items-center gap-2">
             <Image src={Icon} alt="Logo" width={50} height={50}></Image>
-            <span className="w-2"></span>
             <span className="text-2xl">Timetable Together</span>
           </Link>
           <span className="grow"></span>
           {session ? (
             <>
               <span className="text-2xl">{session?.user?.name}</span>
-              <span className="w-2"></span>
               <Timetable labl="Timetable" />
-              <span className="w-2"></span>
               <Logout labl="Sign out" />
             </>
           ) : (
             <>
               <Login labl={"Sign in"} />
-              <span className="w-2"></span>
               <Register labl={"Register"} />
             </>
           )}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,11 +30,11 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body className={clsx(inter.className, "flex h-dvh flex-col")}>
-        <div className="flex rounded-lg bg-slate-200">
+        <header className="mx-2 mt-2 flex items-center rounded-lg bg-slate-200 p-2">
           <Link
-              href="/"
+            href="/"
               className="h-full space-y-2 rounded-lg bg-slate-200 flex flex-row align-middle"
-            >
+          >
             <Image src={Icon} alt="Logo" width={50} height={50}></Image>
             <span className="w-2"></span>
             <span className="text-2xl">Timetable Together</span>
@@ -55,7 +55,7 @@ export default async function RootLayout({
               <Register labl={"Register"} />
             </>
           )}
-        </div>
+        </header>
         <div className="w-dvw min-h-0 grow">{children}</div>
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,11 +33,11 @@ export default async function RootLayout({
         <header className="mx-2 mt-2 flex items-center gap-2 rounded-lg bg-slate-200 p-2">
           <Link href="/" className="mr-auto flex items-center gap-2">
             <Image src={Icon} alt="Logo" width={50} height={50}></Image>
-            <span className="text-2xl">Timetable Together</span>
+            <h1 className="text-2xl">Timetable Together</h1>
           </Link>
           {session ? (
             <>
-              <span className="text-2xl">{session?.user?.name}</span>
+              <h2 className="text-2xl">{session?.user?.name}</h2>
               <Timetable labl="Timetable" />
               <Logout labl="Sign out" />
             </>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export default async function RootLayout({
   const session = await auth();
   return (
     <html lang="en">
-      <body className={clsx(inter.className, "h-dvh w-dvw flex flex-col")}>
+      <body className={clsx(inter.className, "flex h-dvh flex-col")}>
         <div className="w-dvw px-2 pt-2 pb-0 grow-0">
           <div
             className={


### PR DESCRIPTION
- Use flexbox for positioning instead of vertical margins and spans
- Use margin instead of another div with padding
- Use semantic html
- Clean up unnecessary classes

Resolves https://github.com/NhatMinh0208/timetable-together/pull/20#issuecomment-2191483368

Before:

![image](https://github.com/user-attachments/assets/4bc4361a-1ac3-412d-8994-322ce1e4a3a7)

After:

![image](https://github.com/user-attachments/assets/42d94c3a-dab1-44b1-9a45-440b7d2aa70c)

Before (enlarged):

![image](https://github.com/user-attachments/assets/3043ecdd-9063-4583-a6b0-fa2ede9f4f51)

After (enlarged):

![image](https://github.com/user-attachments/assets/a43e0e38-fee4-48e7-8961-03a040a14924)